### PR TITLE
fix: silent crash on startup due to the invalid or empty configuration and device description files

### DIFF
--- a/libsokketter/sources/database_storage.cpp
+++ b/libsokketter/sources/database_storage.cpp
@@ -158,6 +158,8 @@ auto database_storage::load() -> void
     SPDLOG_LOGGER_DEBUG(
         SOKKETTER_LOGGER, "Restoring the device database from '{}' file.", path().string());
 
+    m_devices.clear();
+
     if (!std::filesystem::exists(path()))
     {
         SPDLOG_LOGGER_INFO(
@@ -174,9 +176,20 @@ auto database_storage::load() -> void
     }
 
     nlohmann::json j;
-    file >> j;
+    try
+    {
+        file >> j;
 
-    m_devices = j.get<std::vector<std::shared_ptr<sokketter::power_strip>>>();
+        auto devices = j.get<std::vector<std::shared_ptr<sokketter::power_strip>>>();
+        m_devices = std::move(devices);
+    }
+    catch (const nlohmann::json::exception &exception)
+    {
+        SPDLOG_LOGGER_ERROR(SOKKETTER_LOGGER,
+            "Failed restoring the device database from '{}' file: {}. Starting with an empty "
+            "database.",
+            path().string(), exception.what());
+    }
 }
 
 auto database_storage::remove(std::shared_ptr<sokketter::power_strip> &power_strip) -> void

--- a/sokketter-ui/sources/app_settings_storage.cpp
+++ b/sokketter-ui/sources/app_settings_storage.cpp
@@ -38,6 +38,8 @@ auto app_settings_storage::load() -> void
     SPDLOG_LOGGER_DEBUG(
         APP_LOGGER, "Restoring the application settings from '{}' file.", path().string());
 
+    m_settings = {};
+
     QFileInfo fileInfo(path());
     if (!fileInfo.exists())
     {
@@ -54,9 +56,20 @@ auto app_settings_storage::load() -> void
     }
 
     nlohmann::json j;
-    file >> j;
+    try
+    {
+        file >> j;
 
-    m_settings = j.get<app_settings>();
+        auto settings = j.get<app_settings>();
+        m_settings = std::move(settings);
+    }
+    catch (const nlohmann::json::exception &exception)
+    {
+        SPDLOG_LOGGER_ERROR(APP_LOGGER,
+            "Failed restoring the application settings from '{}' file: {}. Starting with "
+            "default settings.",
+            path().string(), exception.what());
+    }
 }
 
 auto app_settings_storage::path() const -> std::filesystem::path


### PR DESCRIPTION
### Test results:

| ID         | Steps                                                     | Expected                                                                              | Result: Windows x86_64 | Result: Linux x86_64 | Result: macOS arm64 | Result: macOS x86_64 |
| ---------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------- | -------------------- | ------------------- | -------------------- |
| MAN-PER-05 | Corrupt/partial `devices.json`.                           | App logs an error and starts with a usable (empty) database instead of crashing.      | ✅                      | ✅                    | ✅                   | ✅                    |
